### PR TITLE
fix: 修复qwen3.5-plus等DashScope模型流式调用需要incremental_output的问题

### DIFF
--- a/jeecg-boot-starter-ai/src/main/java/org/jeecg/ai/factory/AiModelFactory.java
+++ b/jeecg-boot-starter-ai/src/main/java/org/jeecg/ai/factory/AiModelFactory.java
@@ -403,9 +403,15 @@ public class AiModelFactory {
                     qwenBuilder.maxTokens(maxTokens);
                 }
                 Map<String, Object> extraParams = options.getExtraParams();
+                QwenChatRequestParameters.Builder qwenParamsBuilder = QwenChatRequestParameters.builder()
+                        .supportIncrementalOutput(true);
                 if (null != extraParams && !extraParams.isEmpty()) {
-                    qwenBuilder.defaultRequestParameters(buildQwenRequestParameters(extraParams));
+                    Boolean enableThinking = removeBool(extraParams, "enable_thinking");
+                    if (enableThinking != null) {
+                        qwenParamsBuilder.enableThinking(enableThinking);
+                    }
                 }
+                qwenBuilder.defaultRequestParameters(qwenParamsBuilder.build());
                 chatModel = qwenBuilder.build();
                 break;
             case AIMODEL_TYPE_OLLAMA:


### PR DESCRIPTION
## 关联Issue

修复 jeecgboot/JeecgBoot#9446

## 问题描述

使用DashScope（通义千问）模型进行流式调用时，qwen3.5-plus等新模型默认不返回增量输出，导致每次流式响应返回的是完整内容而非增量内容，造成前端展示重复文本。

## 修复方案

在 `AiModelFactory.createStreamingChatModel` 方法的 QWEN 分支中，通过 `QwenChatRequestParameters` 设置 `supportIncrementalOutput(true)`，确保DashScope流式调用始终启用增量输出模式。

这是一个最小化修改，仅影响流式模型的QWEN分支，不影响其他模型或非流式调用。