### PR TITLE
允许deepseek配置是否开启思考；修改deepseek默认模型为官方最新的模型。

### DIFF
--- a/jeecg-boot-starter-ai/src/main/java/org/jeecg/ai/factory/AiModelFactory.java
+++ b/jeecg-boot-starter-ai/src/main/java/org/jeecg/ai/factory/AiModelFactory.java
@@ -241,7 +241,7 @@ public class AiModelFactory {
                 baseUrl = getString(baseUrl, "https://api.deepseek.com/v1");
                 // 确保baseUrl以v1结尾
                 baseUrl = ensureOpenAiUrlEnd(baseUrl);
-                modelName = getString(modelName, "deepseek-chat");
+                modelName = getString(modelName, "deepseek-v4-flash");
                 OpenAiChatModel.OpenAiChatModelBuilder dsBuilder = OpenAiChatModel.builder()
                         .apiKey(apiKey)
                         .baseUrl(baseUrl)
@@ -459,7 +459,7 @@ public class AiModelFactory {
                 baseUrl = getString(baseUrl, "https://api.deepseek.com/v1");
                 // 确保baseUrl以v1结尾
                 baseUrl = ensureOpenAiUrlEnd(baseUrl);
-                modelName = getString(modelName, "deepseek-chat");
+                modelName = getString(modelName, "deepseek-v4-flash");
                 OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder dsBuilder = OpenAiStreamingChatModel.builder()
                         .apiKey(apiKey)
                         .baseUrl(baseUrl)
@@ -767,7 +767,7 @@ public class AiModelFactory {
         return false;
     }
 
-    
+
 
     /**
      * 构建Qwen自定义请求参数
@@ -858,7 +858,7 @@ public class AiModelFactory {
      * @date 2025/3/12 20:44
      */
     @Nullable
-   public static String ensureOpenAiUrlEnd(String baseUrl) {
+    public static String ensureOpenAiUrlEnd(String baseUrl) {
         if (StringUtils.isNotEmpty(baseUrl)) {
             if (baseUrl.endsWith("/")) {
                 baseUrl = baseUrl.substring(0, baseUrl.length() - 1);

--- a/jeecg-boot-starter-ai/src/main/java/org/jeecg/ai/factory/AiModelFactory.java
+++ b/jeecg-boot-starter-ai/src/main/java/org/jeecg/ai/factory/AiModelFactory.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 /**
  * AI模型工厂
@@ -276,6 +277,8 @@ public class AiModelFactory {
                             .httpClientBuilder(httpClientBuilder);
                     dsBuilder.httpClientBuilder(jdkHttpClientBuilder);
                 }
+                // 处理并传递 DeepSeek 的额外参数
+                applyDeepSeekExtraParams(options.getExtraParams(), dsBuilder::reasoningEffort, dsBuilder::customParameters);
                 chatModel = dsBuilder.build();
                 break;
             case AIMODEL_TYPE_ANTHROPIC:
@@ -492,6 +495,8 @@ public class AiModelFactory {
                             .httpClientBuilder(httpClientBuilder);
                     dsBuilder.httpClientBuilder(jdkHttpClientBuilder);
                 }
+                // 处理并传递 DeepSeek 的额外参数
+                applyDeepSeekExtraParams(options.getExtraParams(), dsBuilder::reasoningEffort, dsBuilder::customParameters);
                 chatModel = dsBuilder.build();
                 break;
             case AIMODEL_TYPE_ANTHROPIC:
@@ -816,6 +821,32 @@ public class AiModelFactory {
             return Boolean.parseBoolean((String) val);
         }
         return null;
+    }
+
+    /**
+     * 将 extraParams 透传到 DeepSeek（OpenAI 兼容协议）的 builder：
+     * reasoning_effort 走 builder 标准方法，其余键（如 thinking）经 customParameters 进请求体顶层。
+     * 非流式/流式 builder 没有公共父类，通过传 setter 方法引用解耦。
+     *
+     * @author sjlei
+     * @date 2026-5-14
+     */
+    private static void applyDeepSeekExtraParams(
+            Map<String, Object> extraParams,
+            Consumer<String> reasoningEffortSetter,
+            Consumer<Map<String, Object>> customParametersSetter
+    ) {
+        if (extraParams == null || extraParams.isEmpty()) {
+            return;
+        }
+        Map<String, Object> copy = new LinkedHashMap<>(extraParams);
+        Object effort = copy.remove("reasoning_effort");
+        if (effort instanceof String) {
+            reasoningEffortSetter.accept((String) effort);
+        }
+        if (!copy.isEmpty()) {
+            customParametersSetter.accept(copy);
+        }
     }
 
     /**


### PR DESCRIPTION

### 一、允许deepseek配置是否开启思考

关闭思考模式可通过配置额外参数：

```json
{
  "thinking": {
    "type": "disabled"
  }
}
```

<img width="470" alt="image" src="https://github.com/user-attachments/assets/bf744f4f-b892-4467-92db-c89087b0b3cf" />

### 二、修改deepseek默认模型为官方最新的模型

根据deepseek官方文档的说明：`deepseek-chat`和`deepseek-reasoner`将于 2026/07/24 弃用。

<img width="535" height="135" alt="image" src="https://github.com/user-attachments/assets/34c123af-7051-4328-a1c9-9bbd52de90bb" />
